### PR TITLE
Fix skip link order and ensure main-content exists in loading/error states

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAccessibilityStore } from '@/stores/accessibility'
 import { useAuthStore } from '@/stores/auth'
@@ -26,12 +26,47 @@ const showHeader = computed(() => {
   return authStore.isAuthenticated
 })
 
+// In non-production environments, verify each rendered route exposes
+// a #main-content target so the global skip link remains functional.
+const ensureMainContentTargetExists = async () => {
+  if (import.meta.env.MODE === 'production') {
+    return
+  }
+
+  // Wait for RouterView/KeepAlive content to finish mounting before checking.
+  await nextTick()
+  await nextTick()
+
+  if (!document.getElementById('main-content')) {
+    console.warn(
+      `[a11y] Missing #main-content on route "${String(route.name)}". Skip link target is required.`,
+    )
+  }
+}
+
+onMounted(() => {
+  void ensureMainContentTargetExists()
+})
+
+watch(
+  () => route.fullPath,
+  () => {
+    void ensureMainContentTargetExists()
+  },
+)
+
 // Note: Authentication is initialized in main.ts before router navigation
 // to ensure auth state is loaded before routing decisions are made
 </script>
 
 <template>
   <div id="app" :class="accessibilityStore.accessibilityClasses" class="app">
+    <!--
+      Place skip link first in the DOM so it is the first focusable element.
+      This ensures keyboard users can bypass global navigation on every route.
+    -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
     <!-- App header with user menu - shown on all pages except login when authenticated -->
     <AppHeader v-if="showHeader" :class="{ 'app-header--wide': wideHeader }" />
 

--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -1,11 +1,112 @@
-import { describe, it, expect } from 'vitest'
-
-import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
 import App from '../App.vue'
 
+let mockedRouteName = 'Dashboard'
+let mockedIsAuthenticated = true
+let mockedRouteFullPath = '/dashboard'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ name: mockedRouteName, fullPath: mockedRouteFullPath }),
+}))
+
+vi.mock('@/stores/accessibility', () => ({
+  useAccessibilityStore: () => ({
+    accessibilityClasses: '',
+  }),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: mockedIsAuthenticated,
+  }),
+}))
+
+const MainContentComponent = defineComponent({
+  template: '<main id="main-content">Main content</main>',
+})
+
+const LoginContentComponent = defineComponent({
+  template: '<main id="main-content">Login content</main>',
+})
+
+const MissingMainContentComponent = defineComponent({
+  template: '<div>Missing main target</div>',
+})
+
+const createRouterViewStub = (routedComponent: object) =>
+  defineComponent({
+    setup(_, { slots }) {
+      return () => slots.default?.({ Component: routedComponent })
+    },
+  })
+
 describe('App', () => {
-  it('mounts renders properly', () => {
-    const wrapper = mount(App)
-    expect(wrapper.text()).toContain('You did it!')
+  beforeEach(() => {
+    mockedRouteName = 'Dashboard'
+    mockedIsAuthenticated = true
+    mockedRouteFullPath = '/dashboard'
+    vi.restoreAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('renders skip link as the first focusable element', () => {
+    const wrapper = mount(App, {
+      global: {
+        stubs: {
+          AppHeader: {
+            template: '<header><a href="#header-menu">Header Menu</a></header>',
+          },
+          RouterView: createRouterViewStub(MainContentComponent),
+        },
+      },
+    })
+
+    const firstFocusableElement = wrapper.element.querySelector(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ) as HTMLAnchorElement | null
+
+    expect(firstFocusableElement).not.toBeNull()
+    expect(firstFocusableElement?.classList.contains('skip-link')).toBe(true)
+    expect(firstFocusableElement?.getAttribute('href')).toBe('#main-content')
+  })
+
+  it('still renders the skip link on the login route', () => {
+    mockedRouteName = 'Login'
+    mockedIsAuthenticated = false
+    mockedRouteFullPath = '/login'
+
+    const wrapper = mount(App, {
+      global: {
+        stubs: {
+          RouterView: createRouterViewStub(LoginContentComponent),
+        },
+      },
+    })
+
+    const skipLink = wrapper.find('a.skip-link')
+    expect(skipLink.exists()).toBe(true)
+    expect(skipLink.attributes('href')).toBe('#main-content')
+  })
+
+  it('warns in non-production mode when main-content target is missing', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn')
+
+    mount(App, {
+      global: {
+        stubs: {
+          AppHeader: {
+            template: '<header><a href="#header-menu">Header Menu</a></header>',
+          },
+          RouterView: createRouterViewStub(MissingMainContentComponent),
+        },
+      },
+    })
+
+    await flushPromises()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Missing #main-content on route "Dashboard"'),
+    )
   })
 })

--- a/src/views/CreateRunView.vue
+++ b/src/views/CreateRunView.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="create-run-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Loading state for initial data -->
-    <LoadingUI
-      v-if="pageLoading === 'loading'"
-      type="spinner"
-      text="Loading form..."
-      centered
-    />
+    <div v-if="pageLoading === 'loading'" id="main-content" class="create-run-main" tabindex="-1">
+      <LoadingUI type="spinner" text="Loading form..." centered />
+    </div>
 
     <!-- Error state for initial data loading -->
-    <div v-else-if="pageLoading === 'error'" class="create-run-error">
+    <div
+      v-else-if="pageLoading === 'error'"
+      id="main-content"
+      class="create-run-main create-run-error"
+      tabindex="-1"
+    >
       <h1>Unable to load form</h1>
       <p>There was an error loading the form. Please try again.</p>
       <AchillesButton @click="loadFormData">Try Again</AchillesButton>
@@ -630,30 +629,6 @@ onMounted(() => {
 .create-run-error p {
   color: var(--color-text-muted, #6b7280);
   margin: 0 0 1.5rem 0;
-}
-
-/* Skip link for keyboard navigation */
-.skip-link {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}
-
-.skip-link:focus {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: auto;
-  height: auto;
-  padding: 1rem 2rem;
-  background: var(--color-primary, #0066cc);
-  color: white;
-  z-index: 1000;
-  outline: 2px solid var(--color-focus, #0066cc);
-  outline-offset: 2px;
 }
 
 /* Mobile responsiveness */

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="dashboard-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Main content -->
     <main id="main-content" class="dashboard-main">
       <div class="dashboard-container">

--- a/src/views/EditRunView.vue
+++ b/src/views/EditRunView.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="edit-run-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Loading state for initial data -->
-    <LoadingUI
-      v-if="pageLoading === 'loading'"
-      type="spinner"
-      text="Loading run..."
-      centered
-    />
+    <div v-if="pageLoading === 'loading'" id="main-content" class="edit-run-main" tabindex="-1">
+      <LoadingUI type="spinner" text="Loading run..." centered />
+    </div>
 
     <!-- Error state for initial data loading -->
-    <div v-else-if="pageLoading === 'error'" class="edit-run-error">
+    <div
+      v-else-if="pageLoading === 'error'"
+      id="main-content"
+      class="edit-run-main edit-run-error"
+      tabindex="-1"
+    >
       <h1>Unable to load run</h1>
       <p>There was an error loading the run. Please try again.</p>
       <AchillesButton @click="loadFormData">Try Again</AchillesButton>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="login-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Main content -->
     <main id="main-content" class="login-main">
       <div class="login-container">
@@ -236,24 +233,6 @@ onMounted(() => {
 </script>
 
 <style scoped>
-/* Skip link for keyboard navigation */
-.skip-link {
-  position: absolute;
-  top: -40px;
-  left: 6px;
-  background: var(--color-focus, #0066cc);
-  color: white;
-  padding: 8px;
-  text-decoration: none;
-  border-radius: 4px;
-  z-index: 1000;
-  transition: top 0.3s;
-}
-
-.skip-link:focus {
-  top: 6px;
-}
-
 /* Main layout */
 .login-view {
   min-height: 100vh;
@@ -452,10 +431,6 @@ onMounted(() => {
 }
 
 /* Reduced motion support */
-.reduced-motion .skip-link {
-  transition: none;
-}
-
 .reduced-motion .form-input {
   transition: none;
 }

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="not-found-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Main content -->
     <main id="main-content" class="not-found-main">
       <div class="not-found-container">

--- a/src/views/OrganizationSettingsView.vue
+++ b/src/views/OrganizationSettingsView.vue
@@ -1,28 +1,36 @@
 <template>
   <div class="org-settings-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Loading state -->
-    <LoadingUI
-      v-if="organizationLoading === 'loading'"
-      type="spinner"
-      text="Loading organization..."
-      centered
-    />
+    <main v-if="organizationLoading === 'loading'" id="main-content" class="org-settings-main">
+      <LoadingUI type="spinner" text="Loading organization..." centered />
+    </main>
 
     <!-- Error state -->
-    <div v-else-if="organizationLoading === 'error'" class="org-settings-error">
-      <h1>Unable to load organization</h1>
-      <p>There was an error loading the organization. Please try again.</p>
-      <AchillesButton @click="loadOrganizationData">Try Again</AchillesButton>
-    </div>
+    <main
+      v-else-if="organizationLoading === 'error'"
+      id="main-content"
+      class="org-settings-main"
+      tabindex="-1"
+    >
+      <div class="org-settings-error">
+        <h1>Unable to load organization</h1>
+        <p>There was an error loading the organization. Please try again.</p>
+        <AchillesButton @click="loadOrganizationData">Try Again</AchillesButton>
+      </div>
+    </main>
 
     <!-- Organization not found -->
-    <div v-else-if="organizationLoading === 'success' && !organization" class="org-settings-error">
-      <h1>Organization not found</h1>
-      <p>The organization you're looking for doesn't exist or has been removed.</p>
-    </div>
+    <main
+      v-else-if="organizationLoading === 'success' && !organization"
+      id="main-content"
+      class="org-settings-main"
+      tabindex="-1"
+    >
+      <div class="org-settings-error">
+        <h1>Organization not found</h1>
+        <p>The organization you're looking for doesn't exist or has been removed.</p>
+      </div>
+    </main>
 
     <!-- Organization loaded successfully -->
     <template v-else-if="organization">

--- a/src/views/OrganizationView.vue
+++ b/src/views/OrganizationView.vue
@@ -1,28 +1,36 @@
 <template>
   <div class="organization-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Loading state for organization data -->
-    <LoadingUI
-      v-if="organizationLoading === 'loading'"
-      type="spinner"
-      text="Loading organization..."
-      centered
-    />
+    <main v-if="organizationLoading === 'loading'" id="main-content" class="organization-main">
+      <LoadingUI type="spinner" text="Loading organization..." centered />
+    </main>
 
     <!-- Error state -->
-    <div v-else-if="organizationLoading === 'error'" class="organization-error">
-      <h1>Unable to load organization</h1>
-      <p>There was an error loading the organization. Please try again.</p>
-      <AchillesButton @click="loadOrganizationData">Try Again</AchillesButton>
-    </div>
+    <main
+      v-else-if="organizationLoading === 'error'"
+      id="main-content"
+      class="organization-main"
+      tabindex="-1"
+    >
+      <div class="organization-error">
+        <h1>Unable to load organization</h1>
+        <p>There was an error loading the organization. Please try again.</p>
+        <AchillesButton @click="loadOrganizationData">Try Again</AchillesButton>
+      </div>
+    </main>
 
     <!-- Organization not found -->
-    <div v-else-if="organizationLoading === 'success' && !organization" class="organization-error">
-      <h1>Organization not found</h1>
-      <p>The organization you're looking for doesn't exist or has been removed.</p>
-    </div>
+    <main
+      v-else-if="organizationLoading === 'success' && !organization"
+      id="main-content"
+      class="organization-main"
+      tabindex="-1"
+    >
+      <div class="organization-error">
+        <h1>Organization not found</h1>
+        <p>The organization you're looking for doesn't exist or has been removed.</p>
+      </div>
+    </main>
 
     <!-- Organization loaded successfully -->
     <template v-else-if="organization">

--- a/src/views/PairingView.vue
+++ b/src/views/PairingView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="pairing-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Screen reader live region for announcements -->
     <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
       {{ srAnnouncement }}
@@ -814,22 +811,6 @@ onActivated(() => {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
-}
-
-/* Skip link for keyboard navigation */
-.skip-link {
-  position: absolute;
-  top: -40px;
-  left: 0;
-  background: var(--color-primary, #0066cc);
-  color: white;
-  padding: 0.5rem 1rem;
-  text-decoration: none;
-  z-index: 100;
-}
-
-.skip-link:focus {
-  top: 0;
 }
 
 /* ==========================================

--- a/src/views/RunView.vue
+++ b/src/views/RunView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="run-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Header -->
     <header class="run-header">
       <div class="run-header__content">

--- a/src/views/UserSettingsView.vue
+++ b/src/views/UserSettingsView.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="settings-view">
-    <!-- Skip link for keyboard navigation -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <!-- Main content -->
     <main id="main-content" class="settings-main">
       <div class="settings-container">

--- a/style.md
+++ b/style.md
@@ -23,6 +23,9 @@ Agents: read this file for style guidance before making UI changes.
 - Provide clear success and error feedback for form actions.
 - Prefer simple, step-by-step flows over complex, multi-panel layouts.
 - Use plain language labels for form fields and actions.
+- Avoid overriding whole blocks of elements with aria-label, as it's easy to break an entire subtree with aria-label.
+
+- use `<main id="main-content" ` for the main content to ensure skip links work. Every page *MUST* have a skip link.
 
 ## Visual Language
 


### PR DESCRIPTION
## Summary
- move the skip link to App so it is the first focusable element on every route
- remove duplicate per-view skip links and redundant skip-link CSS
- ensure loading/error/not-found route branches render a #main-content target
- add an App-level dev warning when a route omits #main-content
- add App unit tests for skip-link ordering and missing-target warning
- include style.md updates from this branch

## Validation
- pnpm test:unit -- src/__tests__/App.spec.ts

Closes #53
