### PR TITLE
Fix active descendant wiring for comboboxes and action menus

### DIFF
--- a/src/__tests__/activeDescendant.spec.ts
+++ b/src/__tests__/activeDescendant.spec.ts
@@ -1,0 +1,96 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import LocationDropdown from '@/components/ui/LocationDropdown.vue'
+import ActionMenu from '@/components/ui/ActionMenu.vue'
+import type { Location } from '@/types'
+
+vi.mock('@/stores/accessibility', () => ({
+  useAccessibilityStore: () => ({
+    accessibilityClasses: ['text-size-medium'],
+  }),
+}))
+
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    value: vi.fn(),
+    writable: true,
+  })
+})
+
+describe('active descendant accessibility wiring', () => {
+  it('keeps focus on the combobox trigger and points aria-activedescendant at the active option', async () => {
+    const locations: Location[] = [
+      {
+        id: 'loc-1',
+        organizationId: 'org-1',
+        name: 'Washington Park',
+        createdAt: new Date('2026-03-16T00:00:00Z'),
+      },
+      {
+        id: 'loc-2',
+        organizationId: 'org-1',
+        name: 'City Park',
+        createdAt: new Date('2026-03-16T00:00:00Z'),
+      },
+    ]
+
+    const wrapper = mount(LocationDropdown, {
+      attachTo: document.body,
+      props: {
+        label: 'Location',
+        locations,
+      },
+    })
+
+    const trigger = wrapper.get('button[role="combobox"]')
+    await trigger.trigger('click')
+    await nextTick()
+
+    expect(document.activeElement).toBe(trigger.element)
+
+    const firstOptionId = wrapper.findAll('li[role="option"]')[0]?.attributes('id')
+    expect(firstOptionId).toBeTruthy()
+    expect(trigger.attributes('aria-activedescendant')).toBe(firstOptionId)
+
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+
+    const secondOptionId = wrapper.findAll('li[role="option"]')[1]?.attributes('id')
+    expect(trigger.attributes('aria-activedescendant')).toBe(secondOptionId)
+
+    wrapper.unmount()
+  })
+
+  it('exposes the active menu item through aria-activedescendant on the focused menu', async () => {
+    const wrapper = mount(ActionMenu, {
+      attachTo: document.body,
+      props: {
+        items: [
+          { id: 'edit', label: 'Edit' },
+          { id: 'delete', label: 'Delete', danger: true },
+        ],
+      },
+      global: {
+        stubs: {
+          'font-awesome-icon': true,
+        },
+      },
+    })
+
+    await wrapper.get('button').trigger('click')
+    await nextTick()
+
+    const menu = wrapper.get('ul[role="menu"]')
+    const menuItems = wrapper.findAll('li[role="menuitem"]')
+
+    expect(menu.attributes('aria-activedescendant')).toBe(menuItems[0]?.attributes('id'))
+
+    await menu.trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+
+    expect(menu.attributes('aria-activedescendant')).toBe(menuItems[1]?.attributes('id'))
+
+    wrapper.unmount()
+  })
+})

--- a/src/components/ui/ActionMenu.vue
+++ b/src/components/ui/ActionMenu.vue
@@ -26,6 +26,7 @@
       :id="menuId"
       ref="menuRef"
       role="menu"
+      :aria-activedescendant="activeDescendantId"
       class="action-menu__dropdown"
       tabindex="-1"
       @keydown="handleMenuKeydown"
@@ -34,7 +35,7 @@
       <li
         v-for="(item, index) in items"
         :key="item.id"
-        :id="`${menuId}-item-${index}`"
+        :id="getMenuItemId(index)"
         role="menuitem"
         class="action-menu__item"
         :class="{
@@ -93,6 +94,21 @@ const activeIndex = ref(-1)
 // Generate unique ID for accessibility associations
 const uniqueId = Math.random().toString(36).substring(2, 9)
 const menuId = computed(() => `action-menu-${uniqueId}`)
+
+// The focused menu element uses aria-activedescendant so assistive technology
+// can announce which menuitem arrow-key navigation has highlighted.
+const activeDescendantId = computed(() => {
+  if (!isOpen.value || activeIndex.value < 0) return undefined
+  return getMenuItemId(activeIndex.value)
+})
+
+/**
+ * Build the DOM id for a rendered menu item.
+ * A dedicated helper keeps the template and aria-activedescendant in sync.
+ */
+function getMenuItemId(index: number): string {
+  return `${menuId.value}-item-${index}`
+}
 
 /**
  * Toggle the menu open/closed

--- a/src/components/ui/LocationDropdown.vue
+++ b/src/components/ui/LocationDropdown.vue
@@ -73,7 +73,6 @@
         role="listbox"
         :aria-label="ariaLabel || label || 'Locations'"
         class="location-dropdown__listbox"
-        tabindex="-1"
         @keydown="handleListboxKeydown"
       >
         <!-- Empty state when no locations available -->
@@ -86,7 +85,7 @@
         <li
           v-for="(location, index) in locations"
           :key="location.id"
-          :id="`${listboxId}-option-${index}`"
+          :id="getOptionId(index)"
           role="option"
           :aria-selected="location.id === modelValue"
           class="location-dropdown__option"
@@ -225,7 +224,7 @@ const hasError = computed(() => props.error || !!props.errorMessage)
 // Computed: ID of the currently active option for aria-activedescendant
 const activeDescendantId = computed(() => {
   if (!isOpen.value || activeIndex.value < 0) return undefined
-  return `${listboxId.value}-option-${activeIndex.value}`
+  return getOptionId(activeIndex.value)
 })
 
 // Computed: the currently selected location object
@@ -257,6 +256,14 @@ function formatCityState(location: Location): string {
 }
 
 /**
+ * Build the DOM id for a rendered option.
+ * This keeps the aria-activedescendant target and the rendered <li> in sync.
+ */
+function getOptionId(index: number): string {
+  return `${listboxId.value}-option-${index}`
+}
+
+/**
  * Toggle dropdown open/closed state
  */
 function toggleDropdown(): void {
@@ -281,9 +288,11 @@ function openDropdown(): void {
   const selectedIndex = props.locations.findIndex((loc) => loc.id === props.modelValue)
   activeIndex.value = selectedIndex >= 0 ? selectedIndex : 0
 
-  // Focus the listbox after it becomes visible
+  // Keep focus on the trigger because it owns aria-activedescendant.
+  // Screen readers only announce the active option reliably when the focused
+  // element is the one exposing the active descendant relationship.
   nextTick(() => {
-    listboxRef.value?.focus()
+    triggerRef.value?.focus()
     scrollActiveOptionIntoView()
   })
 }
@@ -312,16 +321,22 @@ function selectLocation(location: Location): void {
 function scrollActiveOptionIntoView(): void {
   if (activeIndex.value < 0) return
 
-  const optionId = `${listboxId.value}-option-${activeIndex.value}`
+  const optionId = getOptionId(activeIndex.value)
   const optionElement = document.getElementById(optionId)
   optionElement?.scrollIntoView({ block: 'nearest' })
 }
 
 /**
  * Handle keydown events on the trigger button
- * Opens dropdown on arrow down, space, or enter
+ * Opens the dropdown and, once it is open, keeps keyboard navigation on the
+ * trigger so aria-activedescendant can continue to describe the active option.
  */
 function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (isOpen.value) {
+    handlePopupKeydown(event)
+    return
+  }
+
   switch (event.key) {
     case 'ArrowDown':
     case 'ArrowUp':
@@ -345,10 +360,20 @@ function handleTriggerKeydown(event: KeyboardEvent): void {
 }
 
 /**
- * Handle keydown events on the listbox
- * Provides full keyboard navigation for option selection
+ * Handle keydown events on the popup listbox.
+ * This remains as a defensive fallback if focus is moved into the popup by
+ * browser or assistive-technology behavior.
  */
 function handleListboxKeydown(event: KeyboardEvent): void {
+  handlePopupKeydown(event)
+}
+
+/**
+ * Shared keyboard navigation for the open popup.
+ * Keeping this logic in one place prevents the trigger and popup handlers from
+ * drifting apart, which would make keyboard behavior inconsistent.
+ */
+function handlePopupKeydown(event: KeyboardEvent): void {
   const lastIndex = props.locations.length - 1
 
   switch (event.key) {


### PR DESCRIPTION
## Summary

Fix keyboard and screen-reader active item announcements for custom dropdown widgets.

Closes #41.

## What changed

- Keep focus on the LocationDropdown combobox trigger while the popup is open, so aria-activedescendant stays on the focused element
- Centralize option id generation in LocationDropdown so rendered option ids and aria-activedescendant always match
- Add aria-activedescendant support to ActionMenu and centralize menu item id generation there as well
- Add unit tests covering active descendant updates for both widgets during arrow-key navigation

## Why

LocationDropdown already rendered ids on its li role=option elements, but focus was moved into the listbox while aria-activedescendant lived on the trigger button. That breaks the ARIA pattern because the active descendant relationship needs to be exposed from the focused element.

ActionMenu tracked an active index for keyboard navigation but did not expose that active item through aria-activedescendant.

## Testing

- pnpm test:unit --run src/__tests__/activeDescendant.spec.ts
- pnpm type-check

## Manual testing

- Create/Edit Run: open the Location dropdown with keyboard and arrow through options
- Organization Settings: open a user action menu and arrow through menu items
- Confirm screen readers announce the active option/item correctly