### PR TITLE
Demo TanStack Query pattern with RunView migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fortawesome/free-regular-svg-icons": "^7.1.0",
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/vue-fontawesome": "^3.1.3",
+    "@tanstack/vue-query": "^5.92.9",
     "firebase": "^12.4.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fortawesome/vue-fontawesome':
         specifier: ^3.1.3
         version: 3.1.3(@fortawesome/fontawesome-svg-core@7.1.0)(vue@3.5.26(typescript@5.9.3))
+      '@tanstack/vue-query':
+        specifier: ^5.92.9
+        version: 5.92.9(vue@3.5.26(typescript@5.9.3))
       firebase:
         specifier: ^12.4.0
         version: 12.7.0
@@ -980,6 +983,22 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/match-sorter-utils@8.19.4':
+    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
+    engines: {node: '>=12'}
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/vue-query@5.92.9':
+    resolution: {integrity: sha512-jjAZcqKveyX0C4w/6zUqbnqk/XzuxNWaFsWjGTJWULVFizUNeLGME2gf9vVSDclIyiBhR13oZJPPs6fJgfpIJQ==}
+    peerDependencies:
+      '@vue/composition-api': ^1.1.2
+      vue: ^2.6.0 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@tsconfig/node22@22.0.5':
     resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
@@ -2515,6 +2534,9 @@ packages:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
 
@@ -2968,6 +2990,17 @@ packages:
 
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
@@ -4019,6 +4052,20 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/match-sorter-utils@8.19.4':
+    dependencies:
+      remove-accents: 0.5.0
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/vue-query@5.92.9(vue@3.5.26(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.19.4
+      '@tanstack/query-core': 5.90.20
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.26(typescript@5.9.3)
+      vue-demi: 0.14.10(vue@3.5.26(typescript@5.9.3))
 
   '@tsconfig/node22@22.0.5': {}
 
@@ -5691,6 +5738,8 @@ snapshots:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
 
+  remove-accents@0.5.0: {}
+
   request-progress@3.0.0:
     dependencies:
       throttleit: 1.0.1
@@ -6169,6 +6218,10 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@2.2.12: {}
+
+  vue-demi@0.14.10(vue@3.5.26(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.26(typescript@5.9.3)
 
   vue-eslint-parser@10.2.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:

--- a/src/composables/queries/useLocationQuery.ts
+++ b/src/composables/queries/useLocationQuery.ts
@@ -1,0 +1,20 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { useOrganizationRepository } from '@/composables/useRepositories'
+import { queryKeys } from '@/lib/queryKeys'
+import type { Location } from '@/types'
+
+/**
+ * Load a single location by ID.
+ */
+export function useLocationQuery(locationId: MaybeRefOrGetter<string | undefined>) {
+  const organizationRepository = useOrganizationRepository()
+  const normalizedLocationId = computed(() => toValue(locationId))
+  const queryKey = computed(() => queryKeys.locations.detail(normalizedLocationId.value ?? 'unknown'))
+
+  return useQuery<Location | null>({
+    queryKey,
+    enabled: computed(() => !!normalizedLocationId.value),
+    queryFn: () => organizationRepository.getLocation(normalizedLocationId.value!),
+  })
+}

--- a/src/composables/queries/useOrganizationQuery.ts
+++ b/src/composables/queries/useOrganizationQuery.ts
@@ -1,0 +1,22 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { useOrganizationRepository } from '@/composables/useRepositories'
+import { queryKeys } from '@/lib/queryKeys'
+import type { Organization } from '@/types'
+
+/**
+ * Load a single organization by ID.
+ */
+export function useOrganizationQuery(organizationId: MaybeRefOrGetter<string | undefined>) {
+  const organizationRepository = useOrganizationRepository()
+  const normalizedOrganizationId = computed(() => toValue(organizationId))
+  const queryKey = computed(() =>
+    queryKeys.organizations.detail(normalizedOrganizationId.value ?? 'unknown'),
+  )
+
+  return useQuery<Organization | null>({
+    queryKey,
+    enabled: computed(() => !!normalizedOrganizationId.value),
+    queryFn: () => organizationRepository.getOrganization(normalizedOrganizationId.value!),
+  })
+}

--- a/src/composables/queries/useRunQuery.ts
+++ b/src/composables/queries/useRunQuery.ts
@@ -1,0 +1,19 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { useRunRepository } from '@/composables/useRepositories'
+import { queryKeys } from '@/lib/queryKeys'
+import type { Run } from '@/types'
+
+/**
+ * Load a single run by ID.
+ */
+export function useRunQuery(runId: MaybeRefOrGetter<string>) {
+  const runRepository = useRunRepository()
+  const normalizedRunId = computed(() => toValue(runId))
+  const queryKey = computed(() => queryKeys.runs.detail(normalizedRunId.value))
+
+  return useQuery<Run | null>({
+    queryKey,
+    queryFn: () => runRepository.getRun(normalizedRunId.value),
+  })
+}

--- a/src/composables/queries/useRunSignUpsQuery.ts
+++ b/src/composables/queries/useRunSignUpsQuery.ts
@@ -1,0 +1,19 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { useSignUpRepository } from '@/composables/useRepositories'
+import { queryKeys } from '@/lib/queryKeys'
+import type { SignUp } from '@/types'
+
+/**
+ * Load sign-ups for a single run.
+ */
+export function useRunSignUpsQuery(runId: MaybeRefOrGetter<string>) {
+  const signUpRepository = useSignUpRepository()
+  const normalizedRunId = computed(() => toValue(runId))
+  const queryKey = computed(() => queryKeys.signUps.forRun(normalizedRunId.value))
+
+  return useQuery<SignUp[]>({
+    queryKey,
+    queryFn: () => signUpRepository.getSignUpsForRun(normalizedRunId.value),
+  })
+}

--- a/src/composables/queries/useUsersByIdsQuery.ts
+++ b/src/composables/queries/useUsersByIdsQuery.ts
@@ -1,0 +1,29 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useQuery } from '@tanstack/vue-query'
+import { useUserRepository } from '@/composables/useRepositories'
+import { queryKeys } from '@/lib/queryKeys'
+import type { User } from '@/types'
+
+/**
+ * Load a set of users by ID through TanStack Query.
+ * The IDs are normalized so equivalent sets share the same cache entry.
+ */
+export function useUsersByIdsQuery(userIds: MaybeRefOrGetter<string[]>) {
+  const userRepository = useUserRepository()
+
+  // This is a transitional fan-out pattern for v1.
+  // It is acceptable for modest admin-only lists, but the repository layer
+  // should eventually grow a bulk getUsersByIds(ids) method so larger screens
+  // do not need one request per user.
+  const normalizedIds = computed(() => Array.from(new Set(toValue(userIds))).sort())
+  const queryKey = computed(() => queryKeys.users.byIds(normalizedIds.value))
+
+  return useQuery<User[]>({
+    queryKey,
+    enabled: computed(() => normalizedIds.value.length > 0),
+    queryFn: async () => {
+      const users = await Promise.all(normalizedIds.value.map((id) => userRepository.getUser(id)))
+      return users.filter((user): user is User => user !== null)
+    },
+  })
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,17 @@
+import { QueryClient } from '@tanstack/vue-query'
+
+/**
+ * Shared TanStack Query client for the application.
+ * Defaults stay conservative so data is reused briefly without hiding
+ * server updates for long periods.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+})

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -2,6 +2,26 @@
  * Centralized query keys make cache invalidation and query reuse predictable.
  */
 export const queryKeys = {
+  runs: {
+    detail(id: string) {
+      return ['runs', 'detail', id] as const
+    },
+  },
+  organizations: {
+    detail(id: string) {
+      return ['organizations', 'detail', id] as const
+    },
+  },
+  locations: {
+    detail(id: string) {
+      return ['locations', 'detail', id] as const
+    },
+  },
+  signUps: {
+    forRun(runId: string) {
+      return ['sign-ups', 'run', runId] as const
+    },
+  },
   users: {
     byIds(ids: string[]) {
       const normalizedIds = Array.from(new Set(ids)).sort()

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized query keys make cache invalidation and query reuse predictable.
+ */
+export const queryKeys = {
+  users: {
+    byIds(ids: string[]) {
+      const normalizedIds = Array.from(new Set(ids)).sort()
+      return ['users', 'by-ids', normalizedIds] as const
+    },
+  },
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { VueQueryPlugin } from '@tanstack/vue-query'
 import { createPinia } from 'pinia'
 
 // Font Awesome setup: register icons in the library so they can be used
@@ -31,6 +32,7 @@ library.add(
 
 import App from './App.vue'
 import router from './router'
+import { queryClient } from './lib/queryClient'
 import { useAuthStore } from './stores/auth'
 
 const app = createApp(App)
@@ -40,6 +42,7 @@ app.component('font-awesome-icon', FontAwesomeIcon)
 
 // Initialize Pinia first so stores are available
 app.use(createPinia())
+app.use(VueQueryPlugin, { queryClient })
 
 // Initialize authentication state before router navigation
 // This ensures auth state is loaded from sessionStorage/localStorage before routing decisions are made

--- a/src/views/RunView.vue
+++ b/src/views/RunView.vue
@@ -118,7 +118,10 @@
             <!-- Run Admins -->
             <div class="detail-section">
               <h3 class="subsection-title">Run Organizers:</h3>
-              <ul v-if="adminNames.length > 0" class="admin-list">
+              <p v-if="isAdminUsersLoading && adminIds.length > 0" class="no-data">
+                Loading organizers...
+              </p>
+              <ul v-else-if="adminNames.length > 0" class="admin-list">
                 <li v-for="(name, index) in adminNames" :key="index" class="admin-item">
                   {{ name }}
                 </li>
@@ -243,8 +246,8 @@ import { useLocationStore } from '@/stores/location'
 import { useOrganizationStore } from '@/stores/organization'
 import { useSignUpsStore } from '@/stores/signups'
 import { useAuthStore } from '@/stores/auth'
-import { useUsersStore } from '@/stores/users'
 import { useAdminCapabilities } from '@/composables/useAdminCapabilities'
+import { useUsersByIdsQuery } from '@/composables/queries/useUsersByIdsQuery'
 import type { Location, LoadingState } from '@/types'
 
 // Router and stores
@@ -255,7 +258,6 @@ const locationStore = useLocationStore()
 const organizationStore = useOrganizationStore()
 const signUpsStore = useSignUpsStore()
 const authStore = useAuthStore()
-const usersStore = useUsersStore()
 const { canManageRun } = useAdminCapabilities()
 
 // Local state for tracking loading and errors
@@ -370,12 +372,12 @@ const adminIds = computed(() => {
   )
 })
 
+const adminUsersQuery = useUsersByIdsQuery(adminIds)
+const isAdminUsersLoading = computed(() => adminUsersQuery.isPending.value)
+
 // Get the display names of the admins
 const adminNames = computed(() => {
-  return adminIds.value
-    .map((id) => usersStore.getUserById(id))
-    .filter((user) => user !== undefined)
-    .map((user) => user!.displayName)
+  return (adminUsersQuery.data.value ?? []).map((user) => user.displayName)
 })
 
 // Check if the current user can manage this run (is org admin or run admin)
@@ -456,18 +458,6 @@ async function loadRunData(): Promise<void> {
 
     // Load the organization for this run
     await organizationStore.loadOrganization(runsStore.currentRun.organizationId)
-
-    // Determine which admin IDs to load
-    // Use run-specific admins if available, otherwise use org admins
-    let adminIdsToLoad: string[] = []
-    if (runsStore.currentRun.runAdminIds && runsStore.currentRun.runAdminIds.length > 0) {
-      adminIdsToLoad = runsStore.currentRun.runAdminIds
-    } else if (organization.value) {
-      adminIdsToLoad = organization.value.adminIds
-    }
-
-    // Load admin user data for all admin IDs
-    await usersStore.loadUsers(adminIdsToLoad)
 
     // Load sign-ups for this run
     await signUpsStore.loadSignUpsForRun(runId.value)

--- a/src/views/RunView.vue
+++ b/src/views/RunView.vue
@@ -87,31 +87,31 @@
       <div class="run-content">
         <!-- Loading state -->
         <LoadingUI
-          v-if="loading === 'loading'"
+          v-if="isPageLoading"
           type="spinner"
           text="Loading run details..."
           centered
         />
 
         <!-- Error state -->
-        <div v-else-if="loading === 'error'" class="run-error">
+        <div v-else-if="hasPageError" class="run-error">
           <h2>Unable to load run details</h2>
           <p>{{ 'Please try again and contact us if the problem persists.' }}</p>
-          <AchillesButton @click="loadRunData">Try Again</AchillesButton>
+          <AchillesButton @click="retryLoadRunPage">Try Again</AchillesButton>
         </div>
 
         <!-- Run details -->
-        <div v-else-if="runsStore.currentRun" class="run-details-container">
+        <div v-else-if="run" class="run-details-container">
           <CardUI class="run-details-card" title="Run Details">
             <!-- Date and Time -->
             <div class="detail-section">
               <div class="detail-row">
                 <span class="detail-label">Date:</span>
-                <span class="detail-value">{{ formatDate(runsStore.currentRun.date) }}</span>
+                <span class="detail-value">{{ formatDate(run.date) }}</span>
               </div>
               <div class="detail-row">
                 <span class="detail-label">Time:</span>
-                <span class="detail-value">{{ runsStore.currentRun.time }}</span>
+                <span class="detail-value">{{ run.time }}</span>
               </div>
             </div>
 
@@ -222,7 +222,7 @@
     <!-- RSVP Modal -->
     <RSVPModal
       :is-open="isRSVPModalOpen"
-      :run="runsStore.currentRun"
+      :run="run"
       :location-name="locationName"
       :is-editing="isEditingRSVP"
       :existing-sign-up="existingSignUpData"
@@ -242,27 +242,20 @@ import LoadingUI from '@/components/ui/LoadingUI.vue'
 import ModalElement from '@/components/ui/ModalElement.vue'
 import RSVPModal from '@/components/RSVPModal.vue'
 import { useRunsStore } from '@/stores/runs'
-import { useLocationStore } from '@/stores/location'
-import { useOrganizationStore } from '@/stores/organization'
-import { useSignUpsStore } from '@/stores/signups'
 import { useAuthStore } from '@/stores/auth'
 import { useAdminCapabilities } from '@/composables/useAdminCapabilities'
+import { useRunQuery } from '@/composables/queries/useRunQuery'
+import { useOrganizationQuery } from '@/composables/queries/useOrganizationQuery'
+import { useLocationQuery } from '@/composables/queries/useLocationQuery'
+import { useRunSignUpsQuery } from '@/composables/queries/useRunSignUpsQuery'
 import { useUsersByIdsQuery } from '@/composables/queries/useUsersByIdsQuery'
-import type { Location, LoadingState } from '@/types'
 
 // Router and stores
 const router = useRouter()
 const route = useRoute()
 const runsStore = useRunsStore()
-const locationStore = useLocationStore()
-const organizationStore = useOrganizationStore()
-const signUpsStore = useSignUpsStore()
 const authStore = useAuthStore()
 const { canManageRun } = useAdminCapabilities()
-
-// Local state for tracking loading and errors
-const loading = ref<LoadingState>('idle')
-const error = ref<string | null>(null)
 
 // RSVP Modal state
 const isRSVPModalOpen = ref(false)
@@ -341,23 +334,19 @@ function dismissToast(): void {
 
 // Get the run ID from the route parameter
 const runId = computed(() => route.params.id as string)
+const runQuery = useRunQuery(runId)
+const run = computed(() => runQuery.data.value ?? null)
+const organizationQuery = useOrganizationQuery(computed(() => run.value?.organizationId))
+const organization = computed(() => organizationQuery.data.value ?? undefined)
+const locationQuery = useLocationQuery(computed(() => run.value?.locationId))
+const location = computed(() => locationQuery.data.value ?? undefined)
+const signUpsQuery = useRunSignUpsQuery(runId)
+const signUps = computed(() => signUpsQuery.data.value ?? [])
 
 // Computed properties
 
-// Get the location for the current run
-const location = computed((): Location | undefined => {
-  if (!runsStore.currentRun) return undefined
-  return locationStore.getLocationById(runsStore.currentRun.locationId)
-})
-
 // Get the location name from the loaded location
 const locationName = computed(() => location.value?.name || 'Unknown Location')
-
-// Get the organization for the current run
-const organization = computed(() => {
-  if (!runsStore.currentRun) return undefined
-  return organizationStore.getOrganizationById(runsStore.currentRun.organizationId)
-})
 
 // Get the organization name from the loaded organization
 const organizationName = computed(() => organization.value?.name || 'Unknown Organization')
@@ -366,7 +355,7 @@ const organizationName = computed(() => organization.value?.name || 'Unknown Org
 const adminIds = computed(() => {
   return Array.from(
     new Set([
-      ...(runsStore.currentRun?.runAdminIds ?? []),
+      ...(run.value?.runAdminIds ?? []),
       ...(organization.value?.adminIds ?? []),
     ]),
   )
@@ -382,8 +371,8 @@ const adminNames = computed(() => {
 
 // Check if the current user can manage this run (is org admin or run admin)
 const canUserManageRun = computed(() => {
-  if (!runsStore.currentRun) return false
-  return canManageRun(runsStore.currentRun.organizationId, runsStore.currentRun.runAdminIds)
+  if (!run.value) return false
+  return canManageRun(run.value.organizationId, run.value.runAdminIds)
 })
 
 // Check if the current user has signed up for this run
@@ -394,23 +383,20 @@ const isUserSignedUp = computed(() => {
   }
 
   // Get all sign-ups for this run
-  const signUps = signUpsStore.getSignUpsForRun(runId.value)
-
   // Check if any sign-up with status 'yes' or 'maybe' belongs to the current user
-  return signUps.some(
+  return signUps.value.some(
     (signup) => signup.userId === authStore.currentUser!.id && (signup.status === 'yes' || signup.status === 'maybe'),
   )
 })
 
 // Computed: Get existing sign-up data for editing
 const existingSignUpData = computed(() => {
-  if (!runsStore.currentRun || !authStore.currentUser || !isEditingRSVP.value) {
+  if (!run.value || !authStore.currentUser || !isEditingRSVP.value) {
     return undefined
   }
 
   // Find the user's sign-up for this run
-  const signUps = signUpsStore.getSignUpsForRun(runId.value)
-  const userSignUp = signUps.find(
+  const userSignUp = signUps.value.find(
     (signup) => signup.userId === authStore.currentUser!.id && (signup.status === 'yes' || signup.status === 'maybe'),
   )
 
@@ -437,38 +423,28 @@ function formatDate(date: Date): string {
   return runDate.toLocaleDateString('en-US', options)
 }
 
-// Load all data for the run
-async function loadRunData(): Promise<void> {
-  try {
-    loading.value = 'loading'
-    error.value = null
+const isPageLoading = computed(() => {
+  if (runQuery.isPending.value) return true
+  if (!run.value) return false
+  return organizationQuery.isPending.value || locationQuery.isPending.value || signUpsQuery.isPending.value
+})
 
-    // Load the run by ID using the runs store
-    await runsStore.loadRun(runId.value)
+const hasPageError = computed(() => {
+  return Boolean(
+    runQuery.isError.value ||
+      organizationQuery.isError.value ||
+      locationQuery.isError.value ||
+      signUpsQuery.isError.value,
+  )
+})
 
-    // Check if the run was loaded successfully
-    if (!runsStore.currentRun) {
-      // Run not found
-      loading.value = 'success'
-      return
-    }
-
-    // Load the location for this run
-    await locationStore.loadLocation(runsStore.currentRun.locationId)
-
-    // Load the organization for this run
-    await organizationStore.loadOrganization(runsStore.currentRun.organizationId)
-
-    // Load sign-ups for this run
-    await signUpsStore.loadSignUpsForRun(runId.value)
-
-    loading.value = 'success'
-    lastLoadedRunId = runId.value
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load run details'
-    loading.value = 'error'
-    console.error('Error loading run data:', err)
-  }
+async function retryLoadRunPage(): Promise<void> {
+  await Promise.all([
+    runQuery.refetch(),
+    organizationQuery.refetch(),
+    locationQuery.refetch(),
+    signUpsQuery.refetch(),
+  ])
 }
 
 /**
@@ -645,7 +621,7 @@ function closeDeleteRunModal(): void {
  * Deletes the run via the store, then navigates to the dashboard.
  */
 async function confirmDeleteRun(): Promise<void> {
-  if (!runsStore.currentRun) return
+  if (!run.value) return
 
   try {
     isDeletingRun.value = true
@@ -666,35 +642,24 @@ async function confirmDeleteRun(): Promise<void> {
 
 // Navigate to the edit run page
 function navigateToEditRun(): void {
-  if (!runsStore.currentRun) return
-  router.push(`/organizations/${runsStore.currentRun.organizationId}/runs/${runId.value}/edit`)
+  if (!run.value) return
+  router.push(`/organizations/${run.value.organizationId}/runs/${runId.value}/edit`)
 }
 
 // Navigate to the pairings management page for this run
 function navigateToPairings(): void {
-  if (!runsStore.currentRun) return
-  router.push(`/organizations/${runsStore.currentRun.organizationId}/runs/${runId.value}/pairing`)
+  if (!run.value) return
+  router.push(`/organizations/${run.value.organizationId}/runs/${runId.value}/pairing`)
 }
 
 // Initialize on mount — load all run data and register click-outside listener
 onMounted(() => {
-  loadRunData()
   document.addEventListener('click', handleActionsMenuClickOutside, true)
 })
-
-// Track the last loaded run ID so we can detect when the route changes
-// while the component is cached by <KeepAlive>.
-let lastLoadedRunId: string | null = null
 
 // Re-activate the component each time the user navigates to this view.
 // With <KeepAlive>, onMounted only fires once; onActivated fires every time.
 onActivated(() => {
-  // Reload data if the route points to a different run than what was
-  // previously loaded (e.g. navigating from run-1 to run-2).
-  if (runId.value !== lastLoadedRunId) {
-    loadRunData()
-  }
-
   if (runsStore.editRunSaveSuccess) {
     showSuccessToast.value = true
     runsStore.editRunSaveSuccess = false


### PR DESCRIPTION
## Summary

This PR is intentionally a demo slice, not a full TanStack migration.

It shows two levels of adoption:
1. a very small query composable pattern for loading users by ID
2. a more meaningful `RunView` migration that removes imperative fetch orchestration and local fetch state from the view

## What this demonstrates

### Commit 1
- adds TanStack Query app wiring
- adds shared query client and query key helpers
- adds `useUsersByIdsQuery`
- uses that composable in `RunView` for organizer names

This is the small mechanical pattern.

### Commit 2
- adds `useRunQuery`
- adds `useOrganizationQuery`
- adds `useLocationQuery`
- adds `useRunSignUpsQuery`
- migrates `RunView` to query-backed data loading

This is the actual payoff demo.

## RunView before vs after

Before, `RunView` manually:
- tracked local `loading` and `error`
- called `loadRunData()`
- loaded run, location, organization, and sign-ups imperatively
- coordinated route re-activation manually for data loading

After, `RunView`:
- reads server state through query composables
- derives page loading/error state from queries
- no longer orchestrates the load sequence manually
- keeps local UI state local while moving remote data concerns to TanStack Query

## Not included

This PR deliberately does not:
- migrate mutations broadly
- remove Pinia stores from the rest of the app
- change router guards
- add bulk user lookup yet

## Follow-up

Bulk user lookup fast-follow:
- #78

Broader migration plan:
- #77

## Verification

- `pnpm type-check`
- `pnpm lint:check src/views/RunView.vue src/composables/queries/useRunQuery.ts src/composables/queries/useOrganizationQuery.ts src/composables/queries/useLocationQuery.ts src/composables/queries/useRunSignUpsQuery.ts src/lib/queryKeys.ts`
- `pnpm lint:check src/views/RunView.vue src/composables/queries/useUsersByIdsQuery.ts src/lib/queryClient.ts src/lib/queryKeys.ts src/main.ts`