### PR TITLE
Add back button in app header with context-aware aria labels

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -107,13 +107,17 @@ const isDropdownOpen = ref(false)
 // Computed: Get the user's display name from the auth store
 const displayName = computed(() => authStore.userDisplayName || 'User')
 
-// Navigate back to the destination recorded by the current view.
-// Each view sets both backLabel (for the button text) and the back route via
-// navigationStore.previousRoute or a fixed route name in its own navigation logic.
-// AppHeader calls router.back() which is always correct because every view that
-// shows a back button was reached by navigating forward from its back target.
+// Navigate back using the previousRoute recorded by the router guard.
+// This is deterministic and works correctly on deep links and page refreshes,
+// unlike router.back() which relies on browser history being in sync with in-app routes.
+// Falls back to /dashboard when there is no recorded previous route.
 function goBack(): void {
-  router.back()
+  const previousRoute = navigationStore.previousRoute
+  if (previousRoute?.name) {
+    router.push({ name: previousRoute.name, params: previousRoute.params })
+    return
+  }
+  router.push('/dashboard')
 }
 
 // Toggle the dropdown menu open/closed

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,10 +1,15 @@
 <template>
   <header class="app-header">
     <div class="app-header__content">
-      <!-- Left side: Logo/Title area -->
+      <!-- Left side: Back button (shown only when a back destination is set by the current view) -->
       <div class="app-header__left">
-        <button class="app-header__title-button" aria-label="Go to home page" @click="goToHome">
-          Run Coordinator
+        <button
+          v-if="backLabel"
+          class="app-header__back-button"
+          :aria-label="`Back to ${backLabel}`"
+          @click="goBack"
+        >
+          <font-awesome-icon :icon="['fas', 'chevron-left']" aria-hidden="true" />
         </button>
       </div>
 
@@ -79,11 +84,16 @@
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { useNavigationStore } from '@/stores/navigation'
 import UserAvatar from '@/components/ui/UserAvatar.vue'
 
 // Router and stores
 const router = useRouter()
 const authStore = useAuthStore()
+const navigationStore = useNavigationStore()
+
+// The label set by the current view. Null means no back button should be shown.
+const backLabel = computed(() => navigationStore.backLabel)
 
 // Refs for DOM elements
 const userMenuRef = ref<HTMLElement | null>(null)
@@ -97,9 +107,13 @@ const isDropdownOpen = ref(false)
 // Computed: Get the user's display name from the auth store
 const displayName = computed(() => authStore.userDisplayName || 'User')
 
-// Navigate to the dashboard (home page for logged-in users)
-function goToHome(): void {
-  router.push('/dashboard')
+// Navigate back to the destination recorded by the current view.
+// Each view sets both backLabel (for the button text) and the back route via
+// navigationStore.previousRoute or a fixed route name in its own navigation logic.
+// AppHeader calls router.back() which is always correct because every view that
+// shows a back button was reached by navigating forward from its back target.
+function goBack(): void {
+  router.back()
 }
 
 // Toggle the dropdown menu open/closed
@@ -258,25 +272,26 @@ onUnmounted(() => {
   align-items: center;
 }
 
-.app-header__title-button {
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: -0.025em;
+.app-header__back-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
   color: white;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  margin: -0.25rem -0.5rem;
-  border-radius: 0.25rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
   transition: background-color 0.2s ease-in-out;
 }
 
-.app-header__title-button:hover {
+.app-header__back-button:hover {
   background-color: rgba(255, 255, 255, 0.15);
 }
 
-.app-header__title-button:focus-visible {
+.app-header__back-button:focus-visible {
   outline: 2px solid white;
   outline-offset: 2px;
 }
@@ -392,7 +407,7 @@ onUnmounted(() => {
 }
 
 /* Reduced motion */
-.reduced-motion .app-header__title-button,
+.reduced-motion .app-header__back-button,
 .reduced-motion .user-menu__trigger,
 .reduced-motion .user-menu__item {
   transition: none;
@@ -402,10 +417,6 @@ onUnmounted(() => {
 @media (max-width: 640px) {
   .app-header__content {
     padding: 0 0.75rem;
-  }
-
-  .app-header__title-button {
-    font-size: 1.125rem;
   }
 
   .user-menu__trigger {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import {
   faCaretUp,
   faCaretDown,
+  faChevronLeft,
   faCircleCheck,
   faCircleQuestion,
   faPlus,
@@ -21,6 +22,7 @@ import {
 library.add(
   faCaretUp,
   faCaretDown,
+  faChevronLeft,
   faCircleCheck,
   faCircleQuestion,
   faPlus,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useOrganizationStore } from '@/stores/organization'
 import { useRunsStore } from '@/stores/runs'
+import { useNavigationStore } from '@/stores/navigation'
 import { useAdminCapabilities } from '@/composables/useAdminCapabilities'
 import type { UserRole } from '@/types/models'
 import LoginView from '@/views/LoginView.vue'
@@ -141,8 +142,13 @@ const router = createRouter({
 })
 
 // Navigation guards for authentication and role-based access
-router.beforeEach(async (to, _from, next) => {
+router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore()
+
+  // Record where the user is navigating from so views with dynamic back targets
+  // (e.g. RunView, UserSettingsView) can read previousRoute to decide where to go.
+  const navigationStore = useNavigationStore()
+  navigationStore.recordNavigation(from)
 
   // Wait for auth to be initialized before making routing decisions
   // This prevents redirecting to login when a valid session exists in sessionStorage

--- a/src/stores/navigation.ts
+++ b/src/stores/navigation.ts
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+
+/**
+ * Tracks navigation history so the back button in AppHeader can:
+ *   1. Know which route was visited before the current one (for RunView/UserSettings)
+ *   2. Display a descriptive label (e.g. "Boston Achilles") that screen readers
+ *      announce as "Back to Boston Achilles".
+ *
+ * Only views that show a back button are responsible for calling setBackLabel.
+ * The router guard populates previousRoute on every navigation.
+ */
+export const useNavigationStore = defineStore('navigation', () => {
+  // The route the user was on before the current one.
+  // Stored as a plain object (name + params) so we don't hold a live reference.
+  const previousRoute = ref<{ name: string; params: Record<string, string> } | null>(null)
+
+  // Human-readable label for the back-button destination, e.g. "Boston Achilles" or "March 15 Run".
+  // Each view sets this once its data has loaded.
+  const backLabel = ref<string | null>(null)
+
+  /**
+   * Called by the router beforeEach guard before every navigation.
+   * Captures where the user is coming from so views with dynamic back targets
+   * (RunView, UserSettingsView) can read previousRoute.name to decide where to go.
+   */
+  function recordNavigation(from: RouteLocationNormalizedLoaded): void {
+    if (from.name) {
+      previousRoute.value = {
+        name: String(from.name),
+        params: from.params as Record<string, string>,
+      }
+    }
+  }
+
+  /**
+   * Called by each view (in a watch on its loaded data) to provide a
+   * human-readable destination label for the back button aria-label.
+   * Pass null to hide the back button (e.g. on Dashboard where there's nowhere to go back to).
+   */
+  function setBackLabel(label: string | null): void {
+    backLabel.value = label
+  }
+
+  return { previousRoute, backLabel, recordNavigation, setBackLabel }
+})

--- a/src/views/CreateRunView.vue
+++ b/src/views/CreateRunView.vue
@@ -209,8 +209,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onMounted, onActivated } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useNavigationStore } from '@/stores/navigation'
 import CardUI from '@/components/ui/CardUI.vue'
 import AchillesButton from '@/components/ui/AchillesButton.vue'
 import LoadingUI from '@/components/ui/LoadingUI.vue'
@@ -228,6 +229,7 @@ const router = useRouter()
 // Auth is the only Pinia store still in use here — it owns client-side
 // session state, which isn't server data and stays out of TanStack.
 const authStore = useAuthStore()
+const navigationStore = useNavigationStore()
 
 // Get organization ID from route params
 const orgId = computed(() => route.params.orgId as string)
@@ -237,6 +239,15 @@ const orgId = computed(() => route.params.orgId as string)
 // Organization detail (used for the page header/subtitle).
 const organizationQuery = useOrganizationQuery(orgId)
 const organization = computed(() => organizationQuery.data.value ?? undefined)
+
+// Back button label: the org name so the user knows they're returning to that org's page.
+const orgName = computed(() => organization.value?.name ?? null)
+function updateBackLabel(): void {
+  navigationStore.setBackLabel(orgName.value)
+}
+watch(orgName, updateBackLabel)
+onMounted(updateBackLabel)
+onActivated(updateBackLabel)
 
 // Locations for this organization (powers the dropdown). Default to an empty
 // array while loading so the LocationDropdown receives a stable shape.

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -137,7 +137,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onActivated } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import CardUI from '@/components/ui/CardUI.vue'
@@ -145,6 +145,7 @@ import AchillesButton from '@/components/ui/AchillesButton.vue'
 import LoadingUI from '@/components/ui/LoadingUI.vue'
 import RSVPModal from '@/components/RSVPModal.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useNavigationStore } from '@/stores/navigation'
 import { useRunsSignUpsQuery } from '@/composables/queries/useRunsSignUpsQuery'
 import { useUserMemberOrganizationsQuery } from '@/composables/queries/useUserMemberOrganizationsQuery'
 import { useUpcomingRunsForOrganizationsQuery } from '@/composables/queries/useUpcomingRunsForOrganizationsQuery'
@@ -155,6 +156,11 @@ import type { LoadingState, Run, SignUp } from '@/types'
 const router = useRouter()
 const authStore = useAuthStore()
 const { currentUser } = storeToRefs(authStore)
+
+const navigationStore = useNavigationStore()
+// Dashboard has no parent to go back to, so clear the back button on entry.
+onMounted(() => navigationStore.setBackLabel(null))
+onActivated(() => navigationStore.setBackLabel(null))
 
 // === Server state via TanStack Query ===
 

--- a/src/views/EditRunView.vue
+++ b/src/views/EditRunView.vue
@@ -218,7 +218,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch, onMounted, onActivated } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CardUI from '@/components/ui/CardUI.vue'
 import AchillesButton from '@/components/ui/AchillesButton.vue'
@@ -229,11 +229,13 @@ import { useUpdateRunMutation } from '@/composables/mutations/useUpdateRunMutati
 import { useRunQuery } from '@/composables/queries/useRunQuery'
 import { useOrganizationQuery } from '@/composables/queries/useOrganizationQuery'
 import { useLocationsForOrganizationQuery } from '@/composables/queries/useLocationsForOrganizationQuery'
+import { useNavigationStore } from '@/stores/navigation'
 import type { LoadingState, Location, Run } from '@/types'
 
 // Router and route for navigation and params
 const route = useRoute()
 const router = useRouter()
+const navigationStore = useNavigationStore()
 
 // Mutation that persists run edits through TanStack Query.
 // On success, it invalidates the run detail cache so RunView refetches.
@@ -399,6 +401,15 @@ const editRunTitle = computed(() => {
 
   return locationsById.value.get(locationId)?.name || 'Run'
 })
+
+// Back button label: the location name (same as RunView's title) so the user
+// knows exactly which run they'll return to.
+function updateBackLabel(): void {
+  navigationStore.setBackLabel(editRunTitle.value !== 'Run' ? editRunTitle.value : null)
+}
+watch(editRunTitle, updateBackLabel)
+onMounted(updateBackLabel)
+onActivated(updateBackLabel)
 
 // Format the run's date and time for display in the subtitle.
 // Uses the draft values (which are initialized from the current run on load).

--- a/src/views/OrganizationSettingsView.vue
+++ b/src/views/OrganizationSettingsView.vue
@@ -286,8 +286,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onMounted, onActivated } from 'vue'
 import { useRoute } from 'vue-router'
+import { useNavigationStore } from '@/stores/navigation'
 import LoadingUI from '@/components/ui/LoadingUI.vue'
 import AchillesButton from '@/components/ui/AchillesButton.vue'
 import UserAvatar from '@/components/ui/UserAvatar.vue'
@@ -308,12 +309,22 @@ const route = useRoute()
 
 // Store
 const authStore = useAuthStore()
+const navigationStore = useNavigationStore()
 
 // Get organization ID from route params
 const orgId = computed(() => route.params.orgId as string)
 
 // Fetch organization and its members
 const { data: organization, status: organizationStatus } = useOrganizationQuery(orgId)
+
+// Back button label: the org name so the user knows they're returning to that org's page.
+const orgName = computed(() => organization.value?.name ?? null)
+function updateBackLabel(): void {
+  navigationStore.setBackLabel(orgName.value)
+}
+watch(orgName, updateBackLabel)
+onMounted(updateBackLabel)
+onActivated(updateBackLabel)
 
 // Compute all member IDs (admins + non-admins)
 const allMemberIds = computed(() => {

--- a/src/views/OrganizationView.vue
+++ b/src/views/OrganizationView.vue
@@ -175,7 +175,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onActivated } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import CardUI from '@/components/ui/CardUI.vue'
@@ -183,6 +183,7 @@ import AchillesButton from '@/components/ui/AchillesButton.vue'
 import LoadingUI from '@/components/ui/LoadingUI.vue'
 import RSVPModal from '@/components/RSVPModal.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useNavigationStore } from '@/stores/navigation'
 import { useAdminCapabilities } from '@/composables/useAdminCapabilities'
 import { useOrganizationQuery } from '@/composables/queries/useOrganizationQuery'
 import { useRunsForOrganizationQuery } from '@/composables/queries/useRunsForOrganizationQuery'
@@ -198,6 +199,13 @@ const router = useRouter()
 // session state, which is not server data and stays out of TanStack.
 const authStore = useAuthStore()
 const { currentUser } = storeToRefs(authStore)
+
+const navigationStore = useNavigationStore()
+
+// Tell the header to show a back button pointing to the Dashboard.
+// Runs on every activation so the label is always set when arriving at this view.
+onMounted(() => navigationStore.setBackLabel('Dashboard'))
+onActivated(() => navigationStore.setBackLabel('Dashboard'))
 
 // Admin capabilities for checking org admin status (also client-state).
 const { isOrgAdmin } = useAdminCapabilities()

--- a/src/views/PairingView.vue
+++ b/src/views/PairingView.vue
@@ -155,8 +155,9 @@
 
 <script setup lang="ts">
 // Core Vue imports
-import { ref, computed, onMounted, onBeforeUnmount, nextTick, toRaw, watch } from 'vue'
+import { ref, computed, onMounted, onActivated, onBeforeUnmount, nextTick, toRaw, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useNavigationStore } from '@/stores/navigation'
 
 // Type imports
 import type { SignUp, User, LoadingState } from '@/types'
@@ -164,6 +165,7 @@ import type { SignUp, User, LoadingState } from '@/types'
 // Query and mutation hooks (server state)
 import { useRunQuery } from '@/composables/queries/useRunQuery'
 import { useOrganizationQuery } from '@/composables/queries/useOrganizationQuery'
+import { useLocationQuery } from '@/composables/queries/useLocationQuery'
 import { useRunSignUpsQuery } from '@/composables/queries/useRunSignUpsQuery'
 import { useUsersByIdsQuery } from '@/composables/queries/useUsersByIdsQuery'
 import { useUpdateRunMutation } from '@/composables/mutations/useUpdateRunMutation'
@@ -185,6 +187,8 @@ import AddUserDrawer from '@/components/pairing/AddUserDrawer.vue'
 // Route access
 const route = useRoute()
 
+const navigationStore = useNavigationStore()
+
 // Extract run ID from route parameters
 const runId = computed(() => route.params.id as string)
 
@@ -194,6 +198,17 @@ const runId = computed(() => route.params.id as string)
 // and is the parent record for save-pairings updates.
 const runQuery = useRunQuery(runId)
 const run = computed(() => runQuery.data.value ?? undefined)
+
+// Location detail — used for the back button label (mirrors RunView's title).
+const locationQuery = useLocationQuery(computed(() => run.value?.locationId))
+const locationName = computed(() => locationQuery.data.value?.name ?? null)
+
+// Set back label to the location name once it resolves, and on every activation.
+function updateBackLabel(): void {
+  navigationStore.setBackLabel(locationName.value)
+}
+watch(locationName, updateBackLabel)
+onActivated(updateBackLabel)
 
 // Organization detail, gated on the run resolving so we know which org to
 // fetch. Used for the page subtitle and for the Add User drawer's member

--- a/src/views/PairingView.vue
+++ b/src/views/PairingView.vue
@@ -207,7 +207,7 @@ const locationName = computed(() => locationQuery.data.value?.name ?? null)
 function updateBackLabel(): void {
   navigationStore.setBackLabel(locationName.value)
 }
-watch(locationName, updateBackLabel)
+watch(locationName, updateBackLabel, { immediate: true })
 onActivated(updateBackLabel)
 
 // Organization detail, gated on the run resolving so we know which org to

--- a/src/views/RunView.vue
+++ b/src/views/RunView.vue
@@ -358,7 +358,7 @@ function updateBackLabel(): void {
   const label = prev === 'Organization' ? organizationName.value : 'Dashboard'
   navigationStore.setBackLabel(label)
 }
-watch(organizationName, updateBackLabel)
+watch(organizationName, updateBackLabel, { immediate: true })
 onActivated(updateBackLabel)
 
 // Get the list of admin IDs for this run

--- a/src/views/RunView.vue
+++ b/src/views/RunView.vue
@@ -233,6 +233,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onActivated, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useNavigationStore } from '@/stores/navigation'
 import CardUI from '@/components/ui/CardUI.vue'
 import AchillesButton from '@/components/ui/AchillesButton.vue'
 import LoadingUI from '@/components/ui/LoadingUI.vue'
@@ -251,6 +252,7 @@ import { useDeleteRunMutation } from '@/composables/mutations/useDeleteRunMutati
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const navigationStore = useNavigationStore()
 const { canManageRun } = useAdminCapabilities()
 
 // RSVP Modal state
@@ -347,6 +349,17 @@ const locationName = computed(() => location.value?.name || 'Unknown Location')
 
 // Get the organization name from the loaded organization
 const organizationName = computed(() => organization.value?.name || 'Unknown Organization')
+
+// Back button label: show the org name if we came from OrganizationView, otherwise Dashboard.
+// Watches organizationName so the label updates once the query resolves.
+// Also called on activation since <KeepAlive> skips onMounted on re-entry.
+function updateBackLabel(): void {
+  const prev = navigationStore.previousRoute?.name
+  const label = prev === 'Organization' ? organizationName.value : 'Dashboard'
+  navigationStore.setBackLabel(label)
+}
+watch(organizationName, updateBackLabel)
+onActivated(updateBackLabel)
 
 // Get the list of admin IDs for this run
 const adminIds = computed(() => {

--- a/src/views/UserSettingsView.vue
+++ b/src/views/UserSettingsView.vue
@@ -287,9 +287,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted, onActivated } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useAccessibilityStore } from '@/stores/accessibility'
+import { useNavigationStore } from '@/stores/navigation'
 import AchillesButton from '@/components/ui/AchillesButton.vue'
 import { useDraftState } from '@/composables/useDraftState'
 import { useUpdateProfileMutation } from '@/composables/mutations/useUpdateProfileMutation'
@@ -298,6 +299,25 @@ import type { User } from '@/types'
 // Stores
 const authStore = useAuthStore()
 const accessibilityStore = useAccessibilityStore()
+const navigationStore = useNavigationStore()
+
+// Map the previous route name to a human-readable back label.
+// Settings can be reached from any authenticated view, so we cover the known cases
+// and fall back to "Dashboard" for anything unexpected.
+function resolveBackLabel(): string {
+  switch (navigationStore.previousRoute?.name) {
+    case 'Organization': return 'organization'
+    case 'Run': return 'run'
+    case 'RunPairing': return 'pairings'
+    case 'EditRun': return 'edit run'
+    case 'OrganizationSettings': return 'organization settings'
+    case 'CreateRun': return 'create run'
+    default: return 'Dashboard'
+  }
+}
+
+onMounted(() => navigationStore.setBackLabel(resolveBackLabel()))
+onActivated(() => navigationStore.setBackLabel(resolveBackLabel()))
 
 // Mutation for updating profile
 const updateProfileMutation = useUpdateProfileMutation()


### PR DESCRIPTION
Replaces the "Run Coordinator" title text in the header with a back button that appears only on views with a parent to navigate to. Each view sets a human-readable label (e.g. org name, run name) via a new navigationStore so screen readers announce "Back to [destination]".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-aware back button added to the app header with a chevron icon.
  * Back button label and target dynamically reflect the previous screen or relevant entity (organization, run, location) and are kept up to date across lifecycle transitions.
  * Router records previous navigation so the back button reliably returns to the prior destination, with sensible fallback to the dashboard.
  * Header accessibility improved via descriptive back-button labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->